### PR TITLE
Include headings from Hubs wikis in the proposed docs structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,53 @@
 The Hubs documentation site has several different types of content that covers both Hubs and Spoke. Please keep the following structure in mind when creating new documentation files for the site. 
 
 * Getting Started Guides
-  - Guide #1
-  - Guide #2
+  - Guide #1 - Getting Started With Hubs 
+  - Guide #2 - Building a Scene with Spoke
 * Hubs Reference
-  - (Example) User controls
-  - (Example) User list
-  - (Example) Object list 
+  - Scenes
+    - Scene Browser
+    - Lobbies and Rooms
+    - Sharing Invites
+    - Receiving Invites
+    - User List
+    - Chat
+    - Notifications
+    - Name
+    - Entering a Room
+    - Entering on a Mobile VR Headset
+  - In Room Experience
+    - Moving Around
+      - Fly Mode
+    - Growing and Shrinking
+    - Muting
+    - Adding video, audio, 3D models and images
+    - Moving Objects
+    - Menus
+    - Pinning
+    - Blocking
+    - Using Chat
+    - Using the Camera
+    - Mirror Mode
+    - Focus and Track Mode
+    - Using the Pen
+    - Sharing Your Screen or Phone/Web Cam
+    - Controls
+    - User List
+    - Object list
+    - Moderating rooms
+    - Customizing Avatars
+    - Discord Integration
+
 * Spoke Reference
-  - (Example) Asset Panel
+  - Lighting and shadows
+  - Physics and Navigation
+  - Creating Assets for Spoke
+  - Using Spoke Scenes in your own Projects
+  - Keyboard and Mouse Controls
+  - (Example) Asset panel
   - (Example) Element Properties
+
 * For Developers
-  - (Example) Source Code
-  - (Example) Contributing to Hubs and Spoke
+  - Hubs system overview
+  - (Example) source code
+  - (Example contributing to Hubs and spoke


### PR DESCRIPTION
I gathered the content headings from existing Hubs wikis and added them to the proposed documentation structure as a starting point